### PR TITLE
[FIX] Set default limit to None

### DIFF
--- a/mass_editing/models/ir_model_fields.py
+++ b/mass_editing/models/ir_model_fields.py
@@ -27,7 +27,7 @@ class IrModelFields(models.Model):
     _inherit = 'ir.model.fields'
 
     @api.model
-    def search(self, args, offset=0, limit=1, order=None, count=False):
+    def search(self, args, offset=0, limit=None, order=None, count=False):
         model_domain = []
         operator_blacklist = ['ilike']
         for domain in args:


### PR DESCRIPTION
It always returned 1 field, when trying to find fields to translate.